### PR TITLE
Move validation to request classes

### DIFF
--- a/app/Http/Controllers/Api/AuthController.php
+++ b/app/Http/Controllers/Api/AuthController.php
@@ -2,6 +2,8 @@
 namespace App\Http\Controllers\Api;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
+use App\Http\Requests\RegisterRequest;
+use App\Http\Requests\LoginRequest;
 use App\Models\User;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Auth;
@@ -9,17 +11,13 @@ use Illuminate\Support\Facades\Log;
 use Illuminate\Validation\ValidationException;
 
 class AuthController extends Controller{
-    public function register(Request $request){
-        $request->validate([
-            'name' => 'required|string|max:255',
-            'email' => 'required|email|unique:users',
-            'password' => 'required|min:6',
-        ]);
+    public function register(RegisterRequest $request){
+        $data = $request->validated();
         
         $user = User::create([
-            'name' => $request->name,
-            'email' => $request->email,
-            'password' => Hash::make($request->password),
+            'name' => $data['name'],
+            'email' => $data['email'],
+            'password' => Hash::make($data['password']),
             'role_id' => 2  // Default Farmer role_id
         ]);
 
@@ -39,16 +37,13 @@ class AuthController extends Controller{
             ]
         ], 201);
     }
-     public function login(Request $request)
+    public function login(LoginRequest $request)
     {
-        $request->validate([
-            'email' => 'required|email',
-            'password' => 'required',
-        ]);
+        $data = $request->validated();
 
-        $user = User::where('email', $request->email)->first();
+        $user = User::where('email', $data['email'])->first();
 
-        if (!$user || !Hash::check($request->password, $user->password)) {
+        if (!$user || !Hash::check($data['password'], $user->password)) {
             throw ValidationException::withMessages([
                 'email' => ['The provided credentials are incorrect.'],
             ]);

--- a/app/Http/Controllers/Api/StockConditionController.php
+++ b/app/Http/Controllers/Api/StockConditionController.php
@@ -4,6 +4,8 @@ namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
+use App\Http\Requests\CreateStockRequest;
+use App\Http\Requests\UpdateStockRequest;
 use App\Models\StockCondition;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
@@ -245,19 +247,10 @@ class StockConditionController extends Controller
         ]);
     }
 
-    public function createStock(Request $request)
+    public function createStock(CreateStockRequest $request)
     {
         try {
-            $data = $request->validate([
-                'bean_type' => 'required|string|max:255',
-                'quantity' => 'required|numeric|min:0',
-                'temperature' => 'required|numeric',
-                'humidity' => 'required|numeric|min:0|max:100',
-                'status' => 'required|string|in:Good,Warning,Critical',
-                'location' => 'required|string|max:255',
-                'air_condition' => 'required|string|max:255',
-                'action_taken' => 'nullable|string'
-            ]);
+            $data = $request->validated();
 
             $stock = new StockCondition();
             $stock->fill($data);
@@ -299,7 +292,7 @@ class StockConditionController extends Controller
         ]);
     }
 
-    public function updateStock(Request $request, $id)
+    public function updateStock(UpdateStockRequest $request, $id)
     {
         $user = Auth::user();
         $stock = StockCondition::find($id);
@@ -311,16 +304,7 @@ class StockConditionController extends Controller
             ], 404);
         }
 
-        $data = $request->validate([
-            'bean_type' => 'sometimes|required|string',
-            'quantity' => 'sometimes|required|numeric',
-            'temperature' => 'sometimes|required|numeric',
-            'humidity' => 'sometimes|required|numeric',
-            'status' => 'sometimes|required|string',
-            'location' => 'sometimes|required|string',
-            'air_condition' => 'sometimes|required|string',
-            'action_taken' => 'nullable|string'
-        ]);
+        $data = $request->validated();
 
         $data['last_updated'] = now();
         $stock->update($data);

--- a/app/Http/Requests/CreateStockRequest.php
+++ b/app/Http/Requests/CreateStockRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CreateStockRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'bean_type' => 'required|string|max:255',
+            'quantity' => 'required|numeric|min:0',
+            'temperature' => 'required|numeric',
+            'humidity' => 'required|numeric|min:0|max:100',
+            'status' => 'required|string|in:Good,Warning,Critical',
+            'location' => 'required|string|max:255',
+            'air_condition' => 'required|string|max:255',
+            'action_taken' => 'nullable|string',
+        ];
+    }
+}

--- a/app/Http/Requests/LoginRequest.php
+++ b/app/Http/Requests/LoginRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class LoginRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'email' => 'required|email',
+            'password' => 'required',
+        ];
+    }
+}

--- a/app/Http/Requests/RegisterRequest.php
+++ b/app/Http/Requests/RegisterRequest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class RegisterRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'name' => 'required|string|max:255',
+            'email' => 'required|email|unique:users',
+            'password' => 'required|min:6',
+        ];
+    }
+}

--- a/app/Http/Requests/UpdateStockRequest.php
+++ b/app/Http/Requests/UpdateStockRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateStockRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'bean_type' => 'sometimes|required|string',
+            'quantity' => 'sometimes|required|numeric',
+            'temperature' => 'sometimes|required|numeric',
+            'humidity' => 'sometimes|required|numeric',
+            'status' => 'sometimes|required|string',
+            'location' => 'sometimes|required|string',
+            'air_condition' => 'sometimes|required|string',
+            'action_taken' => 'nullable|string',
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- add request classes for auth and stock actions
- use new request classes in controllers

## Testing
- `php --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684eff0562c4832ea01060d781e927b1