### PR TITLE
Remove role_id references

### DIFF
--- a/app/Http/Controllers/Api/AuthController.php
+++ b/app/Http/Controllers/Api/AuthController.php
@@ -18,7 +18,6 @@ class AuthController extends Controller{
             'name' => $data['name'],
             'email' => $data['email'],
             'password' => Hash::make($data['password']),
-            'role_id' => 2  // Default Farmer role_id
         ]);
 
         // Make sure role exists and assign it
@@ -32,7 +31,6 @@ class AuthController extends Controller{
                 'id' => $user->id,
                 'name' => $user->name,
                 'email' => $user->email,
-                'role_id' => 2,
                 'role' => 'Farmer'
             ]
         ], 201);
@@ -58,7 +56,6 @@ class AuthController extends Controller{
                 'id' => $user->id,
                 'name' => $user->name,
                 'email' => $user->email,
-                'role_id' => $user->role_id,
                 'roles' => $user->getRoleNames()
             ]
         ];
@@ -66,7 +63,6 @@ class AuthController extends Controller{
         // Add debug logging
         Log::info('User login successful:', [
             'user_id' => $user->id,
-            'role_id' => $user->role_id,
             'roles' => $user->getRoleNames()->toArray()
         ]);
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -14,8 +14,7 @@ class User extends Authenticatable
     protected $fillable = [
         'name',
         'email',
-        'password',
-        'role_id'
+        'password'
     ];
 
     protected $hidden = [

--- a/database/migrations/2025_05_30_000000_drop_role_id_from_users_table.php
+++ b/database/migrations/2025_05_30_000000_drop_role_id_from_users_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            if (Schema::hasColumn('users', 'role_id')) {
+                $table->dropForeign(['role_id']);
+                $table->dropColumn('role_id');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->unsignedBigInteger('role_id')->nullable()->after('password');
+            $table->foreign('role_id')->references('id')->on('roles')->onDelete('set null');
+        });
+    }
+};

--- a/database/seeders/AdminUserSeeder.php
+++ b/database/seeders/AdminUserSeeder.php
@@ -3,19 +3,20 @@
 namespace Database\Seeders;
 
 use Illuminate\Database\Seeder;
-use Illuminate\Support\Facades\DB;
+use App\Models\User;
+use Spatie\Permission\Models\Role;
 use Illuminate\Support\Facades\Hash;
 
 class AdminUserSeeder extends Seeder
 {
     public function run()
     {
-        DB::table('users')->insert([
+        $user = User::create([
             'name' => 'Admin User',
             'email' => 'admin@example.com',
             'password' => Hash::make('password123'),
-            'role_id' => 1, // Admin role
-            'created_at' => now()
         ]);
+
+        $user->assignRole('Admin');
     }
 }


### PR DESCRIPTION
## Summary
- drop `role_id` column with new migration
- update `User` model fillable
- clean up Auth controller responses and logging
- use `assignRole` in `AdminUserSeeder`

## Testing
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684f00314158832ea9ab3f24a48f4a16