### PR TITLE
Add strict types and type hints

### DIFF
--- a/app/Enums/Role.php
+++ b/app/Enums/Role.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace App\Enums;
 

--- a/app/Http/Controllers/Api/AuthController.php
+++ b/app/Http/Controllers/Api/AuthController.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
@@ -10,13 +11,15 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
 use App\Enums\Role;
 
+use Illuminate\Http\JsonResponse;
+
 class AuthController extends Controller
 {
     public function __construct(private AuthService $authService)
     {
     }
 
-    public function register(RegisterRequest $request)
+    public function register(RegisterRequest $request): JsonResponse
     {
         $user = $this->authService->register($request->validated());
 
@@ -32,20 +35,20 @@ class AuthController extends Controller
         ], 201);
     }
 
-    public function login(LoginRequest $request)
+    public function login(LoginRequest $request): JsonResponse
     {
         $response = $this->authService->login($request->validated());
 
         return response()->json($response);
     }
 
-    public function logout(Request $request)
+    public function logout(Request $request): JsonResponse
     {
         $request->user()->currentAccessToken()->delete();
         return response()->json(['message' => 'Logged out']);
     }
 
-    public function createFarmer(Request $request)
+    public function createFarmer(Request $request): JsonResponse
     {
         try {
             $user = Auth::user();

--- a/app/Http/Controllers/Api/StockConditionController.php
+++ b/app/Http/Controllers/Api/StockConditionController.php
@@ -1,8 +1,11 @@
 <?php
+declare(strict_types=1);
 
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use App\Http\Requests\CreateStockRequest;
 use App\Http\Requests\UpdateStockRequest;
@@ -22,7 +25,7 @@ class StockConditionController extends Controller
     {
     }
 
-    public function index()
+    public function index(): JsonResponse|LengthAwarePaginator
     {
         /** @var User $user */
         $user = Auth::user();
@@ -44,7 +47,7 @@ class StockConditionController extends Controller
         ]);
     }
 
-    public function show(StockCondition $stockCondition)
+    public function show(StockCondition $stockCondition): StockCondition|JsonResponse
     {
         /** @var User $user */
         $user = Auth::user();
@@ -57,7 +60,7 @@ class StockConditionController extends Controller
         return response()->json(['message' => 'Forbidden'], 403);
     }
 
-    public function store(Request $request)
+    public function store(Request $request): JsonResponse
     {
         try {
             /** @var User $user */
@@ -135,7 +138,7 @@ class StockConditionController extends Controller
         }
     }
 
-    public function update(Request $request, StockCondition $stockCondition)
+    public function update(Request $request, StockCondition $stockCondition): StockCondition|JsonResponse
     {
         /** @var User $user */
         $user = Auth::user();
@@ -161,7 +164,7 @@ class StockConditionController extends Controller
         return $stockCondition;
     }
 
-    public function destroy(StockCondition $stockCondition)
+    public function destroy(StockCondition $stockCondition): JsonResponse
     {
         /** @var User $user */
         $user = Auth::user();
@@ -175,7 +178,7 @@ class StockConditionController extends Controller
         return response()->json(['message' => 'Stock condition deleted successfully']);
     }
 
-    public function getAllStockConditions(Request $request)
+    public function getAllStockConditions(Request $request): JsonResponse
     {
         try {
             $user = Auth::user();
@@ -223,7 +226,7 @@ class StockConditionController extends Controller
         }
     }
 
-    public function getStockConditionsByUserId($user_id)
+    public function getStockConditionsByUserId(int $user_id): JsonResponse
     {
         $stockConditions = StockCondition::query()
             ->where('user_id', (int)$user_id)
@@ -238,7 +241,7 @@ class StockConditionController extends Controller
         ]);
     }
 
-    public function getStocks()
+    public function getStocks(): JsonResponse
     {
         $user = Auth::user();
         $query = StockCondition::with('user');
@@ -253,7 +256,7 @@ class StockConditionController extends Controller
         ]);
     }
 
-    public function createStock(CreateStockRequest $request)
+    public function createStock(CreateStockRequest $request): JsonResponse
     {
         try {
             $data = $request->validated();
@@ -276,7 +279,7 @@ class StockConditionController extends Controller
         }
     }
 
-    public function getStock($id)
+    public function getStock(int $id): JsonResponse
     {
         $user = Auth::user();
         $stock = StockCondition::with('user')->find($id);
@@ -294,7 +297,7 @@ class StockConditionController extends Controller
         ]);
     }
 
-    public function updateStock(UpdateStockRequest $request, $id)
+    public function updateStock(UpdateStockRequest $request, int $id): JsonResponse
     {
         $user = Auth::user();
         $stock = StockCondition::find($id);
@@ -317,7 +320,7 @@ class StockConditionController extends Controller
         ]);
     }
 
-    public function deleteStock($id)
+    public function deleteStock(int $id): JsonResponse
     {
         $user = Auth::user();
         $stock = StockCondition::find($id);

--- a/app/Http/Controllers/Api/UserController.php
+++ b/app/Http/Controllers/Api/UserController.php
@@ -1,12 +1,15 @@
 <?php
+declare(strict_types=1);
 
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use App\Services\AuthService;
 use Spatie\Permission\Models\Role as PermissionRole;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Database\Eloquent\Collection;
 use App\Enums\Role;
 
 class UserController extends Controller
@@ -15,12 +18,12 @@ class UserController extends Controller
     {
     }
 
-    public function index()
+    public function index(): Collection
     {
         return \App\Models\User::with('roles')->get();
     }
 
-    public function store(Request $request)
+    public function store(Request $request): JsonResponse
     {
         try {
             $validated = $request->validate([
@@ -52,7 +55,7 @@ class UserController extends Controller
         }
     }
 
-    public function getRoles()
+    public function getRoles(): JsonResponse
     {
         return response()->json([
             'success' => true,

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace App\Http\Controllers;
 

--- a/app/Http/Requests/CreateStockRequest.php
+++ b/app/Http/Requests/CreateStockRequest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace App\Http\Requests;
 

--- a/app/Http/Requests/LoginRequest.php
+++ b/app/Http/Requests/LoginRequest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace App\Http\Requests;
 

--- a/app/Http/Requests/RegisterRequest.php
+++ b/app/Http/Requests/RegisterRequest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace App\Http\Requests;
 

--- a/app/Http/Requests/UpdateStockRequest.php
+++ b/app/Http/Requests/UpdateStockRequest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace App\Http\Requests;
 

--- a/app/Models/StockCondition.php
+++ b/app/Models/StockCondition.php
@@ -1,9 +1,12 @@
 <?php
+declare(strict_types=1);
 
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use App\Models\User;
 
 class StockCondition extends Model
 {
@@ -22,8 +25,8 @@ class StockCondition extends Model
         'last_updated'
     ];
 
-    public function user()
+    public function user(): BelongsTo
     {
-        return $this->belongsTo(\App\Models\User::class);
+        return $this->belongsTo(User::class);
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace App\Models;
 
@@ -6,6 +7,8 @@ use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Sanctum\HasApiTokens;
 use Spatie\Permission\Traits\HasRoles;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use App\Models\StockCondition;
 
 class User extends Authenticatable
 {
@@ -26,8 +29,8 @@ class User extends Authenticatable
         'email_verified_at' => 'datetime',
     ];
 
-    public function stockConditions()
+    public function stockConditions(): HasMany
     {
-        return $this->hasMany(\App\Models\StockCondition::class);
+        return $this->hasMany(StockCondition::class);
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace App\Providers;
 

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace App\Providers;
 

--- a/app/Services/AuthService.php
+++ b/app/Services/AuthService.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace App\Services;
 

--- a/app/Services/StockService.php
+++ b/app/Services/StockService.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace App\Services;
 

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;

--- a/bootstrap/providers.php
+++ b/bootstrap/providers.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 return [
     App\Providers\AppServiceProvider::class,

--- a/config/app.php
+++ b/config/app.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 return [
 

--- a/config/auth.php
+++ b/config/auth.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 return [
 

--- a/config/cache.php
+++ b/config/cache.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 use Illuminate\Support\Str;
 

--- a/config/database.php
+++ b/config/database.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 use Illuminate\Support\Str;
 

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 return [
 

--- a/config/logging.php
+++ b/config/logging.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 use Monolog\Handler\NullHandler;
 use Monolog\Handler\StreamHandler;

--- a/config/mail.php
+++ b/config/mail.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 return [
 

--- a/config/permission.php
+++ b/config/permission.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 return [
 

--- a/config/queue.php
+++ b/config/queue.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 return [
 

--- a/config/sanctum.php
+++ b/config/sanctum.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 use Laravel\Sanctum\Sanctum;
 

--- a/config/services.php
+++ b/config/services.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 return [
 

--- a/config/session.php
+++ b/config/session.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 use Illuminate\Support\Str;
 

--- a/database/factories/StockConditionFactory.php
+++ b/database/factories/StockConditionFactory.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Database\Factories;
 

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Database\Factories;
 

--- a/database/migrations/0001_01_01_000000_create_users_table.php
+++ b/database/migrations/0001_01_01_000000_create_users_table.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;

--- a/database/migrations/0001_01_01_000001_create_cache_table.php
+++ b/database/migrations/0001_01_01_000001_create_cache_table.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;

--- a/database/migrations/0001_01_01_000002_create_jobs_table.php
+++ b/database/migrations/0001_01_01_000002_create_jobs_table.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;

--- a/database/migrations/2024_01_01_000000_create_roles_table.php
+++ b/database/migrations/2024_01_01_000000_create_roles_table.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;

--- a/database/migrations/2024_01_01_add_role_id_to_users_table.php
+++ b/database/migrations/2024_01_01_add_role_id_to_users_table.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;

--- a/database/migrations/2025_05_20_050058_create_personal_access_tokens_table.php
+++ b/database/migrations/2025_05_20_050058_create_personal_access_tokens_table.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;

--- a/database/migrations/2025_05_26_050736_create_permission_tables.php
+++ b/database/migrations/2025_05_26_050736_create_permission_tables.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;

--- a/database/migrations/2025_05_26_073321_create_stock_conditions_table.php
+++ b/database/migrations/2025_05_26_073321_create_stock_conditions_table.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;

--- a/database/migrations/2025_05_30_000000_drop_role_id_from_users_table.php
+++ b/database/migrations/2025_05_30_000000_drop_role_id_from_users_table.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;

--- a/database/seeders/AdminUserSeeder.php
+++ b/database/seeders/AdminUserSeeder.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Database\Seeders;
 

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Database\Seeders;
 

--- a/database/seeders/RoleSeeder.php
+++ b/database/seeders/RoleSeeder.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Database\Seeders;
 

--- a/public/index.php
+++ b/public/index.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 use Illuminate\Foundation\Application;
 use Illuminate\Http\Request;

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\Api\AuthController;

--- a/routes/console.php
+++ b/routes/console.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 use Illuminate\Support\Facades\Route;
 

--- a/tests/Feature/ExampleTest.php
+++ b/tests/Feature/ExampleTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Tests\Feature;
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Tests;
 

--- a/tests/Unit/ExampleTest.php
+++ b/tests/Unit/ExampleTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Tests\Unit;
 


### PR DESCRIPTION
## Summary
- enforce `strict_types` across PHP files
- specify types for controllers and model relations
- enable strict types in PHPUnit tests

## Testing
- `composer test` *(fails: command not found)*
- `./vendor/bin/phpunit --testdox` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684f03c24ee0832e92f0324b0b360004