### PR TITLE
Add feature tests for auth and stocks

### DIFF
--- a/database/factories/StockConditionFactory.php
+++ b/database/factories/StockConditionFactory.php
@@ -3,22 +3,28 @@ declare(strict_types=1);
 
 namespace Database\Factories;
 
+use App\Models\StockCondition;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\StockCondition>
+ * @extends Factory<StockCondition>
  */
 class StockConditionFactory extends Factory
 {
-    /**
-     * Define the model's default state.
-     *
-     * @return array<string, mixed>
-     */
+    protected $model = StockCondition::class;
+
     public function definition(): array
     {
         return [
-            //
+            'bean_type' => $this->faker->word(),
+            'quantity' => $this->faker->numberBetween(1, 1000),
+            'temperature' => $this->faker->randomFloat(1, 10, 40),
+            'humidity' => $this->faker->randomFloat(1, 10, 90),
+            'status' => $this->faker->randomElement(['Good', 'Warning', 'Critical']),
+            'location' => $this->faker->city(),
+            'air_condition' => $this->faker->word(),
+            'action_taken' => $this->faker->sentence(),
+            'last_updated' => now(),
         ];
     }
 }

--- a/tests/CreatesApplication.php
+++ b/tests/CreatesApplication.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests;
+
+use Illuminate\Contracts\Console\Kernel;
+
+trait CreatesApplication
+{
+    public function createApplication()
+    {
+        $app = require __DIR__.'/../bootstrap/app.php';
+
+        $app->make(Kernel::class)->bootstrap();
+
+        return $app;
+    }
+}

--- a/tests/Feature/AuthTest.php
+++ b/tests/Feature/AuthTest.php
@@ -1,0 +1,67 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use App\Models\User;
+use Spatie\Permission\Models\Role;
+
+class AuthTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Role::create(['name' => 'Admin', 'guard_name' => 'web']);
+        Role::create(['name' => 'Farmer', 'guard_name' => 'web']);
+    }
+
+    public function test_user_can_register(): void
+    {
+        $response = $this->postJson('/api/register', [
+            'name' => 'John Doe',
+            'email' => 'john@example.com',
+            'password' => 'secret123',
+        ]);
+
+        $response->assertStatus(201)
+            ->assertJsonStructure([
+                'success',
+                'message',
+                'data' => ['id', 'name', 'email', 'role'],
+            ]);
+
+        $this->assertDatabaseHas('users', ['email' => 'john@example.com']);
+    }
+
+    public function test_user_can_login_and_access_protected_route(): void
+    {
+        $user = User::factory()->create([
+            'email' => 'login@example.com',
+            'password' => bcrypt('password123'),
+        ]);
+        $user->assignRole('Farmer');
+
+        $login = $this->postJson('/api/login', [
+            'email' => 'login@example.com',
+            'password' => 'password123',
+        ]);
+
+        $login->assertStatus(200)->assertJsonStructure(['access_token']);
+
+        $token = $login->json('access_token');
+
+        $this->withHeader('Authorization', 'Bearer ' . $token)
+            ->getJson('/api/stocks')
+            ->assertStatus(200);
+    }
+
+    public function test_protected_route_requires_authentication(): void
+    {
+        $this->getJson('/api/stocks')->assertStatus(401);
+    }
+}

--- a/tests/Feature/StockConditionTest.php
+++ b/tests/Feature/StockConditionTest.php
@@ -1,0 +1,69 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use App\Models\User;
+use App\Models\StockCondition;
+use Laravel\Sanctum\Sanctum;
+use Spatie\Permission\Models\Role;
+
+class StockConditionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Role::create(['name' => 'Admin', 'guard_name' => 'web']);
+        Role::create(['name' => 'Farmer', 'guard_name' => 'web']);
+    }
+
+    public function test_authenticated_user_can_create_stock_condition(): void
+    {
+        $user = User::factory()->create();
+        $user->assignRole('Farmer');
+
+        Sanctum::actingAs($user);
+
+        $data = StockCondition::factory()->make()->toArray();
+
+        $response = $this->postJson('/api/stocks', $data);
+
+        $response->assertStatus(201)
+            ->assertJsonFragment(['success' => true]);
+
+        $this->assertDatabaseHas('stock_conditions', [
+            'bean_type' => $data['bean_type'],
+            'user_id' => $user->id,
+        ]);
+    }
+
+    public function test_authenticated_user_can_update_stock_condition(): void
+    {
+        $user = User::factory()->create();
+        $user->assignRole('Farmer');
+        $stock = StockCondition::factory()->for($user)->create();
+
+        Sanctum::actingAs($user);
+
+        $update = [
+            'temperature' => 22.5,
+            'humidity' => 55,
+        ];
+
+        $response = $this->putJson("/api/stocks/{$stock->id}", $update);
+
+        $response->assertStatus(200)
+            ->assertJsonFragment(['success' => true]);
+
+        $this->assertDatabaseHas('stock_conditions', [
+            'id' => $stock->id,
+            'temperature' => 22.5,
+            'humidity' => 55,
+        ]);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -7,5 +7,5 @@ use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
 {
-    //
+    use CreatesApplication;
 }


### PR DESCRIPTION
## Summary
- create app bootstrap for tests
- define a model factory for `StockCondition`
- add feature tests for authentication with Sanctum
- add feature tests for creating and updating stocks

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f091aa730832ea667452f425debcf