### PR TITLE
Use request classes for user creation

### DIFF
--- a/app/Http/Controllers/Api/AuthController.php
+++ b/app/Http/Controllers/Api/AuthController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
+use App\Http\Requests\CreateFarmerRequest;
 use App\Http\Requests\RegisterRequest;
 use App\Http\Requests\LoginRequest;
 use App\Services\AuthService;
@@ -48,7 +49,7 @@ class AuthController extends Controller
         return response()->json(['message' => 'Logged out']);
     }
 
-    public function createFarmer(Request $request): JsonResponse
+    public function createFarmer(CreateFarmerRequest $request): JsonResponse
     {
         try {
             $user = Auth::user();
@@ -67,13 +68,7 @@ class AuthController extends Controller
                 ], 403);
             }
 
-            $validated = $request->validate([
-                'name' => 'required|string|max:255',
-                'email' => 'required|email|unique:users',
-                'password' => 'required|min:6',
-            ]);
-
-            $newUser = $this->authService->createFarmer($validated);
+            $newUser = $this->authService->createFarmer($request->validated());
 
             return response()->json([
                 'success' => true,

--- a/app/Http/Controllers/Api/UserController.php
+++ b/app/Http/Controllers/Api/UserController.php
@@ -5,7 +5,7 @@ namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
 use Illuminate\Http\JsonResponse;
-use Illuminate\Http\Request;
+use App\Http\Requests\CreateUserRequest;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use App\Http\Resources\UserResource;
 use App\Services\AuthService;
@@ -28,17 +28,10 @@ class UserController extends Controller
         return UserResource::collection($users);
     }
 
-    public function store(Request $request): JsonResponse
+    public function store(CreateUserRequest $request): JsonResponse
     {
         try {
-            $validated = $request->validate([
-                'name' => 'required|string|max:255',
-                'email' => 'required|email|unique:users',
-                'password' => 'required|min:6',
-                'role' => 'required|in:' . Role::ADMIN . ',' . Role::FARMER,
-            ]);
-
-            $user = $this->authService->createUser($validated);
+            $user = $this->authService->createUser($request->validated());
 
             return (new UserResource($user->load('roles')))
                 ->additional([

--- a/app/Http/Requests/CreateFarmerRequest.php
+++ b/app/Http/Requests/CreateFarmerRequest.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CreateFarmerRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'name' => 'required|string|max:255',
+            'email' => 'required|email|unique:users',
+            'password' => 'required|min:6',
+        ];
+    }
+}

--- a/app/Http/Requests/CreateUserRequest.php
+++ b/app/Http/Requests/CreateUserRequest.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use App\Enums\Role;
+
+class CreateUserRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'name' => 'required|string|max:255',
+            'email' => 'required|email|unique:users',
+            'password' => 'required|min:6',
+            'role' => 'required|in:' . Role::ADMIN . ',' . Role::FARMER,
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- move farmer/user validation rules into new FormRequest classes
- type-hint new requests in `AuthController` and `UserController`

## Testing
- `phpunit` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684f0e6b12bc832eb2b8d73d28f64bcd