### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -1,0 +1,40 @@
+name: Laravel CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          extensions: sqlite
+          coverage: none
+
+      - name: Install Composer dependencies
+        run: composer install --no-progress --no-interaction --prefer-dist
+
+      - name: Run Pint
+        run: vendor/bin/pint --test
+
+      - name: PHP syntax check
+        run: |
+          find . -path ./vendor -prune -o -name '*.php' -print0 | xargs -0 -n 1 php -l
+
+      - name: Prepare application
+        run: |
+          cp .env.testing .env
+          php artisan key:generate
+          php artisan migrate --seed --force
+
+      - name: Run PHPUnit tests
+        run: vendor/bin/phpunit


### PR DESCRIPTION
## Summary
- add a Laravel CI GitHub workflow that installs dependencies, runs lint checks, prepares the app and executes PHPUnit tests

## Testing
- `composer install` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f0e6ba338832eb6f0ded177804bcb