### PR TITLE
Add PHP Docker setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+node_modules
+vendor
+storage/*.key
+.idea
+.vscode
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+FROM php:8.3-fpm
+
+# Install system dependencies and PHP extensions
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        git \
+        unzip \
+        libpng-dev \
+        libonig-dev \
+        libxml2-dev \
+        libzip-dev \
+        libpq-dev \
+    && docker-php-ext-install \
+        bcmath \
+        exif \
+        pcntl \
+        pdo_mysql \
+        pdo_pgsql \
+        gd \
+        mbstring \
+        zip \
+        xml \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Composer
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+
+WORKDIR /var/www/html
+
+COPY . .
+
+RUN composer install --no-interaction --prefer-dist --optimize-autoloader
+
+CMD ["php-fpm"]

--- a/README.md
+++ b/README.md
@@ -97,3 +97,14 @@ The `StockConditionResource` describes a stock record along with the owning user
   "updated_at": "2024-01-01T12:00:00Z"
 }
 ```
+
+## Docker Setup
+
+To build and run the containers, execute:
+
+```bash
+docker-compose up --build
+```
+
+The `app` service uses PHP 8.3 with Composer and connects to the `mysql` and `redis` containers defined in `docker-compose.yml`.
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,39 @@
+version: '3.9'
+
+services:
+    app:
+        build: .
+        volumes:
+            - .:/var/www/html
+        ports:
+            - "8000:8000"
+        depends_on:
+            - db
+        environment:
+            DB_HOST: db
+            DB_DATABASE: laravel
+            DB_USERNAME: root
+            DB_PASSWORD: password
+
+    db:
+        image: mysql:8.0
+        restart: always
+        ports:
+            - "3306:3306"
+        environment:
+            MYSQL_ROOT_PASSWORD: password
+            MYSQL_DATABASE: laravel
+        volumes:
+            - db-data:/var/lib/mysql
+
+    redis:
+        image: redis:alpine
+        restart: always
+        ports:
+            - "6379:6379"
+        volumes:
+            - redis-data:/data
+
+volumes:
+    db-data:
+    redis-data:


### PR DESCRIPTION
## Summary
- add `Dockerfile` with PHP 8.3 and composer
- configure `docker-compose.yml` with app, MySQL and Redis
- ignore dependencies in `.dockerignore`
- document Docker usage in README

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f0e6ba22c832ea3554daeb8834fed