### PR TITLE
Add comprehensive tests

### DIFF
--- a/tests/Feature/AdminActionsTest.php
+++ b/tests/Feature/AdminActionsTest.php
@@ -1,0 +1,99 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use App\Models\User;
+use Laravel\Sanctum\Sanctum;
+use Spatie\Permission\Models\Role;
+
+class AdminActionsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Role::create(['name' => 'Admin', 'guard_name' => 'web']);
+        Role::create(['name' => 'Farmer', 'guard_name' => 'web']);
+    }
+
+    public function test_admin_can_create_farmer(): void
+    {
+        $admin = User::factory()->create();
+        $admin->assignRole('Admin');
+
+        Sanctum::actingAs($admin);
+
+        $data = [
+            'name' => 'Test Farmer',
+            'email' => 'farmer@example.com',
+            'password' => 'password123',
+        ];
+
+        $response = $this->postJson('/api/admin/create-farmer', $data);
+
+        $response->assertStatus(201)
+            ->assertJsonFragment(['success' => true]);
+
+        $this->assertDatabaseHas('users', ['email' => 'farmer@example.com']);
+    }
+
+    public function test_non_admin_cannot_create_farmer(): void
+    {
+        $farmer = User::factory()->create();
+        $farmer->assignRole('Farmer');
+
+        Sanctum::actingAs($farmer);
+
+        $response = $this->postJson('/api/admin/create-farmer', [
+            'name' => 'Another Farmer',
+            'email' => 'another@example.com',
+            'password' => 'password123',
+        ]);
+
+        $response->assertStatus(403);
+    }
+
+    public function test_admin_can_access_user_list(): void
+    {
+        $admin = User::factory()->create();
+        $admin->assignRole('Admin');
+
+        Sanctum::actingAs($admin);
+
+        $response = $this->getJson('/api/users');
+
+        $response->assertStatus(200);
+    }
+
+    public function test_farmer_cannot_access_user_list(): void
+    {
+        $farmer = User::factory()->create();
+        $farmer->assignRole('Farmer');
+
+        Sanctum::actingAs($farmer);
+
+        $response = $this->getJson('/api/users');
+
+        $response->assertStatus(403);
+    }
+
+    public function test_create_farmer_validation_failure(): void
+    {
+        $admin = User::factory()->create();
+        $admin->assignRole('Admin');
+
+        Sanctum::actingAs($admin);
+
+        $response = $this->postJson('/api/admin/create-farmer', [
+            'name' => 'Invalid Farmer',
+            // email missing
+            'password' => 'password123',
+        ]);
+
+        $response->assertStatus(500);
+    }
+}

--- a/tests/Unit/AuthServiceTest.php
+++ b/tests/Unit/AuthServiceTest.php
@@ -1,0 +1,53 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use App\Services\AuthService;
+use App\Models\User;
+use Illuminate\Support\Facades\Hash;
+use Spatie\Permission\Models\Role;
+
+class AuthServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected AuthService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Role::create(['name' => 'Admin', 'guard_name' => 'web']);
+        Role::create(['name' => 'Farmer', 'guard_name' => 'web']);
+        $this->service = new AuthService();
+    }
+
+    public function test_register_assigns_farmer_role(): void
+    {
+        $user = $this->service->register([
+            'name' => 'John Doe',
+            'email' => 'john@example.com',
+            'password' => 'secret',
+        ]);
+
+        $this->assertDatabaseHas('users', ['email' => 'john@example.com']);
+        $this->assertTrue(Hash::check('secret', $user->password));
+        $this->assertTrue($user->hasRole('Farmer'));
+    }
+
+    public function test_login_returns_token_and_user_details(): void
+    {
+        $user = User::factory()->create(['password' => Hash::make('password')]);
+        $user->assignRole('Farmer');
+
+        $response = $this->service->login([
+            'email' => $user->email,
+            'password' => 'password',
+        ]);
+
+        $this->assertArrayHasKey('access_token', $response);
+        $this->assertSame($user->email, $response['user']['email']);
+    }
+}

--- a/tests/Unit/StockServiceTest.php
+++ b/tests/Unit/StockServiceTest.php
@@ -1,0 +1,62 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use App\Services\StockService;
+use App\Models\User;
+use App\Models\StockCondition;
+use Laravel\Sanctum\Sanctum;
+use Spatie\Permission\Models\Role;
+
+class StockServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected StockService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Role::create(['name' => 'Admin', 'guard_name' => 'web']);
+        Role::create(['name' => 'Farmer', 'guard_name' => 'web']);
+        $this->service = new StockService();
+    }
+
+    public function test_create_stock_sets_user_id(): void
+    {
+        $user = User::factory()->create();
+        $user->assignRole('Farmer');
+        Sanctum::actingAs($user);
+
+        $data = StockCondition::factory()->make()->toArray();
+
+        $stock = $this->service->createStock($data);
+
+        $this->assertSame($user->id, $stock->user_id);
+        $this->assertNotNull($stock->last_updated);
+        $this->assertDatabaseHas('stock_conditions', ['id' => $stock->id]);
+    }
+
+    public function test_update_stock_modifies_record(): void
+    {
+        $user = User::factory()->create();
+        $user->assignRole('Farmer');
+        $stock = StockCondition::factory()->for($user)->create();
+
+        $updated = $this->service->updateStock($stock, [
+            'temperature' => 18,
+            'humidity' => 50,
+        ]);
+
+        $this->assertSame(18.0, $updated->temperature);
+        $this->assertSame(50.0, $updated->humidity);
+        $this->assertDatabaseHas('stock_conditions', [
+            'id' => $stock->id,
+            'temperature' => 18.0,
+            'humidity' => 50.0,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- test admin-only operations and validation errors
- cover AuthService and StockService service classes

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f0e6d1190832eb3719df10acf22f9